### PR TITLE
Allow users to specify their configuration entry point

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -3,12 +3,12 @@ import PrismicConfig from './prismic-configuration';
 
 const DEFAULT_CONFIG_PATH = './prismic-configuration.js';
 
-function makeTemplate(name, url, configuration, innerFolder, instructions, isQuickstart) {
+function makeTemplate(name, url, configuration, innerFolder, instructions, isQuickstart, ignoreConf = false) {
   const config = configuration || DEFAULT_CONFIG_PATH;
   return {
     name,
     url,
-    configuration: config,
+    configuration: ignoreConf ? null : config,
     innerFolder,
     instructions,
     isQuickstart: isQuickstart || false,
@@ -37,7 +37,7 @@ export default {
     display(messages) {
       if (typeof messages === 'string') {
         process.stdout.write(`${messages}\n`);
-      } else {
+      } else if (typeof messages.join === 'function') {
         process.stdout.write(`${messages.join('\n')}\n`);
       }
     },
@@ -80,10 +80,10 @@ export default {
   },
   Theme: {
     defaultConfigPath: DEFAULT_CONFIG_PATH,
-    make(name, url, tmpFolder, innerFolder) {
+    make(name, url, customConfigPath, ignoreConf, tmpFolder, innerFolder) {
       return {
         tmpFolder,
-        template: makeTemplate(name, url, this.defaultConfigPath, innerFolder),
+        template: makeTemplate(name, url, customConfigPath || this.defaultConfigPath, innerFolder, ignoreConf),
       };
     },
   },

--- a/lib/prismic.js
+++ b/lib/prismic.js
@@ -83,7 +83,6 @@ async function init(config, domain, args, theme) {
 }
 
 async function initWithTheme(config, url, args) {
-  console.log(config, url, args);
   try {
     const theme = await Repository.validateTheme(url, args['--conf'], args['--ignore-conf']);
     return await init(config, null, args, theme);

--- a/lib/prismic.js
+++ b/lib/prismic.js
@@ -85,7 +85,7 @@ async function init(config, domain, args, theme) {
 async function initWithTheme(config, url, args) {
   try {
     const opts = {
-      confPath: args['--conf'] || Helpers.Theme.defaultConfigPath,
+      configPath: args['--conf'] || Helpers.Theme.defaultConfigPath,
       ignoreConf: args['--ignore-conf'],
     };
 

--- a/lib/prismic.js
+++ b/lib/prismic.js
@@ -55,7 +55,9 @@ function help() {
         { name: 'password', description: 'The password of the account to use.' },
         { name: 'folder', description: 'The folder to create the new project.' },
         { name: 'template', description: 'Project template to use (see the list command for available templates).' },
-        { name: 'noconfirm', description: 'Prevent the interactive mode. Fails if informations are missing' },
+        { name: 'noconfirm', description: 'Prevent the interactive mode. Fails if informations are missing.' },
+        { name: 'conf', description: 'Specify path to prismic configuration file. Used with `theme` command.' },
+        { name: 'ignore-conf', description: 'Ignores prismic configuration file. Used with `theme` command.' },
       ],
     },
   ]));
@@ -81,8 +83,9 @@ async function init(config, domain, args, theme) {
 }
 
 async function initWithTheme(config, url, args) {
+  console.log(config, url, args);
   try {
-    const theme = await Repository.validateTheme(url);
+    const theme = await Repository.validateTheme(url, args['--conf'], args['--ignore-conf']);
     return await init(config, null, args, theme);
   } catch (err) {
     return Helpers.UI.display(`Repository creation aborted: ${err}`);

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -219,10 +219,13 @@ async function readZipAndCreateRepoWithCustomTypes(newRepository, base, domain, 
     shell.cp('-R', tmpfolder, folder);
     // the tmp_dir is cleaned after copy
     shell.rm('-Rf', tmpfolder);
-    Template.replace(folder, template, [{
-      pattern: /https:\/\/your-repo-name\.prismic\.io\/api/,
-      value: Helpers.Domain.api(base, domain),
-    }]);
+
+    if (template.configuration) {
+      Template.replace(folder, template, [{
+        pattern: /https:\/\/your-repo-name\.prismic\.io\/api/,
+        value: Helpers.Domain.api(base, domain),
+      }]);
+    }
   };
   // Create repository if needed
   if (newRepository) {
@@ -325,11 +328,12 @@ function promptThemeURL(themeURL) {
   }]);
 }
 
-function checkThemeConfig(themeTmpFolder) {
-  return shell.test('-f', path.join(themeTmpFolder, Helpers.Theme.defaultConfigPath));
+function checkThemeConfig(themeTmpFolder, customConfigPath) {
+  const configPath = customConfigPath || Helpers.Theme.defaultConfigPath;
+  return shell.test('-f', path.join(themeTmpFolder, configPath));
 }
 
-async function validateTheme(themeURL) {
+async function validateTheme(themeURL, customConfigPath = null, ignoreConf = false) {
   async function retry(url, message) {
     if (message) Helpers.UI.display(message);
     const answers = await promptThemeURL(themeURL);
@@ -343,10 +347,10 @@ async function validateTheme(themeURL) {
     const themeData = isValidThemeURL(themeURL);
     if (themeData) {
       const tmpFolder = await Template.unzip(themeData.url, themeData.innerFolder);
-      const isValidConfig = checkThemeConfig(tmpFolder);
+      const isValidConfig = checkThemeConfig(tmpFolder, customConfigPath);
 
-      if (isValidConfig) {
-        return Helpers.Theme.make(themeData.name, themeData.url, tmpFolder, themeData.innerFolder);
+      if (ignoreConf || isValidConfig) {
+        return Helpers.Theme.make(themeData.name, themeData.url, customConfigPath, ignoreConf, tmpFolder, themeData.innerFolder);
       }
       return retry(themeURL, 'Invalid theme provided, check your zip file.');
     }

--- a/lib/repository.js
+++ b/lib/repository.js
@@ -333,11 +333,13 @@ function checkThemeConfig(themeTmpFolder, customConfigPath) {
   return shell.test('-f', path.join(themeTmpFolder, configPath));
 }
 
-async function validateTheme(themeURL, { ignoreConf, configPath }) {
+async function validateTheme(themeURL, opts) {
+  const { ignoreConf, configPath } = opts;
+
   async function retry(url, message) {
     if (message) Helpers.UI.display(message);
     const answers = await promptThemeURL(themeURL);
-    return validateTheme(answers.url);
+    return validateTheme(answers.url, opts);
   }
 
   if (!themeURL) return retry();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1802,7 +1802,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1823,12 +1824,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1843,17 +1846,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1970,7 +1976,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1982,6 +1989,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1996,6 +2004,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2003,12 +2012,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -2027,6 +2038,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2107,7 +2119,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2119,6 +2132,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2204,7 +2218,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2240,6 +2255,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2259,6 +2275,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2302,12 +2319,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Some of Prismic example repositories don't have a configuration file at the root of their repository. This PR allows user to specify an entry point for their configuration file.

To try it out:
```bash
prismic theme https://github.com/prismicio/reactjs-website --conf src/prismic-configuration.js
```

I also added the possibility of skipping the process of updating the configuration file:
```bash
prismic theme https://github.com/prismicio/reactjs-website --ignore-conf
```