### PR TITLE
Include `.cdn` in Repository regex

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -222,7 +222,7 @@ async function readZipAndCreateRepoWithCustomTypes(newRepository, base, domain, 
 
     if (template.configuration) {
       Template.replace(folder, template, [{
-        pattern: /https:\/\/your-repo-name\.prismic\.io\/api/,
+        pattern: /https:\/\/your-repo-name(\.cdn)?\.prismic\.io\/api/,
         value: Helpers.Domain.api(base, domain),
       }]);
     }
@@ -377,7 +377,7 @@ async function heroku(templates, templateName) {
   Helpers.UI.display('Initialize local project...');
   await Template.unzip(answers.template.url, answers.template.innerFolder);
   Template.replace('.', answers.template, [{
-    pattern: /['"]https:\/\/your-repo-name\.prismic\.io\/api['"]/,
+    pattern: /['"]https:\/\/your-repo-name(\.cdn)?\.prismic\.io\/api['"]/,
     value: 'process.env.PRISMIC_ENDPOINT',
   }]);
   Helpers.UI.display('Running npm install...');


### PR DESCRIPTION
#### Why

Some prismic API endpoints include a `.cdn` string.
We should make `Prismic theme` work with these URLs too. 

#### What changed:

I Replaced regex  test: `https:\/\/your-repo-name\.prismic\.io\/api`
with `https:\/\/your-repo-name(\.cdn)?\.prismic\.io\/api`.