### PR TITLE
fix(inquirer): fix validate of domain

### DIFF
--- a/lib/repository.js
+++ b/lib/repository.js
@@ -78,9 +78,8 @@ function promptName(domain) {
     name: 'domain',
     message: 'Name your prismic repository: ',
     default: domain,
-    validate(value) {
-      return new RegExp('^[\\-\\w]+$').test(value) ? true : 'Your repository name can only contains alphanumeric characters, underscores or dashes';
-    },
+    validate: (value) =>
+       new RegExp('^[a-zA-Z0-9\-]*$').test(value) ? true : 'Your repository name can only contains alphanumeric characters and dashes',
   }]);
 }
 


### PR DESCRIPTION
Hello folks 👋 

It seems that your cli doesn't validate the domain name, and so I got confronted to a strange error and I don't know why (`This Repository already exists, please choose another name.`)

It came to the fact that repository can't contains underscores anymore, but the validate function of the domain name (in the inquirer) was wrong (don't know if the validate function was never called or the regex was just not correct anymore)