### PR TITLE
Update README.md to include NuxtJS as supported JS project

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This is a command line tool to bootstrap Javascript project using [prismic.io](h
 * [NodeJS](https://nodejs.org/) ([ExpressJS](https://expressjs.com/))
 * [ReactJS](https://facebook.github.io/react/)
 * [Angular 2.0](https://angular.io/)
+* [NuxtJS](https://nuxtjs.org/)
 
 It is meant to install globally:
 


### PR DESCRIPTION
NuxtJS guides refer to using this cli.

![Nuxt_js_Sample_multi-page_website_with_navigation___Prismic_Help_Center](https://user-images.githubusercontent.com/114459/86873416-60c5a780-c11d-11ea-9940-3719f4060ef6.png)

Add NuxtJS to this README.
ref: https://user-guides.prismic.io/en/articles/2831943-nuxt-js-sample-multi-page-website-with-navigation

Not sure if VueJS should also be added?