### PR TITLE
Support Storybook stories both custom and generated from the UI builder

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,11 +65,12 @@
     "mocha": "^5",
     "nock": "^13.0.5",
     "nyc": "^14",
+    "rimraf": "^3.0.2",
     "ts-node": "^8",
     "typescript": "^3.3"
   },
   "engines": {
-    "node": ">=15.0.0"
+    "node": ">14.0.0"
   },
   "files": [
     "/bin",
@@ -103,9 +104,9 @@
   },
   "repository": "prismicio/prismic-cli",
   "scripts": {
-    "postpack": "rm -f oclif.manifest.json",
+    "postpack": "rimraf oclif.manifest.json",
     "posttest": "eslint . --ext .ts --config .eslintrc",
-    "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
+    "prepack": "rimraf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "test": "nyc --extension .ts mocha \"test/**/*.test.ts\"",
     "version": "oclif-dev readme && git add README.md"
   },

--- a/src/generators/prismic-generator.ts
+++ b/src/generators/prismic-generator.ts
@@ -186,6 +186,5 @@ export interface Documents {
 export interface SliceMachineJson {
   apiEndpoint: string;
   libraries: Array<string>;
-  _latest: string;
   storybook?: string;
 }

--- a/src/generators/slicemachine/create-slice/index.ts
+++ b/src/generators/slicemachine/create-slice/index.ts
@@ -151,6 +151,5 @@ export default class CreateSlice extends PrismicGenerator {
 
 export interface SliceMachineConfig {
   libraries: Array<string>;
-  _latest: string;
   apiEndpoint: string;
 }

--- a/src/generators/slicemachine/setup/index.ts
+++ b/src/generators/slicemachine/setup/index.ts
@@ -4,6 +4,7 @@ import modifyNuxtConfig from './modify-nuxt-config'
 import chalk from 'chalk'
 import message from './message'
 import {existsSync} from 'fs'
+import { default as addStoryBookConfig } from '../storybook/modify-nuxt-config'
 
 const {SM_FILE} = require('sm-commons/consts')
 
@@ -148,9 +149,7 @@ export default class SliceMachine extends PrismicGenerator {
 
     if (this.framework === 'nuxt') {
       const config = this.readDestination('nuxt.config.js')
-
       const updatedConfig = modifyNuxtConfig(config, this.domain)
-
       this.writeDestination('nuxt.config.js', updatedConfig)
     }
 
@@ -166,7 +165,6 @@ export default class SliceMachine extends PrismicGenerator {
     }
     this.fs.copyTpl(this.templatePath('default/**'), this.destinationPath(), {
       domain: this.domain,
-      latest: '0.0.43',
       defaultLibrary: defaultLibForFrameWork(this.framework),
     })
 

--- a/src/generators/slicemachine/setup/templates/default/sm.json
+++ b/src/generators/slicemachine/setup/templates/default/sm.json
@@ -2,6 +2,5 @@
   "apiEndpoint": "https://<%= domain %>.cdn.prismic.io/api/v2",
   "libraries": [
     "<%= defaultLibrary %>"
-  ],
-  "_latest": "<%= latest %>"
+  ]
 }

--- a/src/generators/slicemachine/storybook/modify-nuxt-config.ts
+++ b/src/generators/slicemachine/storybook/modify-nuxt-config.ts
@@ -28,7 +28,6 @@ export default function modifyNuxtConfig(source: string, libraryNames: Array<str
       toGeneratedSlicePath(libraryName)
     ])
   }, [])
-  console.log({ pathsToSlices})
 
   traverse(ast, {
     ObjectExpression(path) {

--- a/src/generators/slicemachine/storybook/modify-nuxt-config.ts
+++ b/src/generators/slicemachine/storybook/modify-nuxt-config.ts
@@ -71,7 +71,6 @@ export default function modifyNuxtConfig(source: string, libraryNames: Array<str
                     }, [])
 
                     libraryNames.forEach(lib => {
-                      console.log({libLoop: lib, values, pathLib: pathString(lib)})
                       if (values.includes(pathString(lib)) === false && t.isArrayExpression(storyBookProps.value)) {
                         storyBookProps.value.elements.push(toCustomSlicePath(lib))
                         storyBookProps.value.elements.push(toGeneratedSlicePath(lib))

--- a/src/generators/slicemachine/storybook/modify-nuxt-config.ts
+++ b/src/generators/slicemachine/storybook/modify-nuxt-config.ts
@@ -18,9 +18,17 @@ function getKeys(properties: Array<t.ObjectMethod | t.ObjectProperty | t.SpreadE
 export default function modifyNuxtConfig(source: string, libraryNames: Array<string>): string {
   const ast = parser.parse(source, {sourceType: 'module'})
 
-  const pathString = (lib: string) => npath.join('~', lib, '**', '*.stories.[tj]s')
-  const toSlicePath = (libName: string) => t.stringLiteral(pathString(libName))
-  const pathsToSlices = libraryNames.map(libraryName => toSlicePath(libraryName))
+  const pathString = (libPath: string) => npath.posix.join('~', libPath, '**', '*.stories.[tj]s')
+
+  const toCustomSlicePath = (libName: string) => t.stringLiteral(pathString(libName))
+  const toGeneratedSlicePath = (libName: string) => t.stringLiteral(pathString(npath.posix.join('.slicemachine', 'assets', libName)))
+  const pathsToSlices = libraryNames.reduce<Array<t.StringLiteral>>((acc, libraryName) => {
+    return acc.concat([
+      toCustomSlicePath(libraryName),
+      toGeneratedSlicePath(libraryName)
+    ])
+  }, [])
+  console.log({ pathsToSlices})
 
   traverse(ast, {
     ObjectExpression(path) {
@@ -63,8 +71,10 @@ export default function modifyNuxtConfig(source: string, libraryNames: Array<str
                     }, [])
 
                     libraryNames.forEach(lib => {
+                      console.log({libLoop: lib, values, pathLib: pathString(lib)})
                       if (values.includes(pathString(lib)) === false && t.isArrayExpression(storyBookProps.value)) {
-                        storyBookProps.value.elements.push(toSlicePath(lib))
+                        storyBookProps.value.elements.push(toCustomSlicePath(lib))
+                        storyBookProps.value.elements.push(toGeneratedSlicePath(lib))
                       }
                     })
                   }

--- a/src/generators/slicemachine/storybook/next.ts
+++ b/src/generators/slicemachine/storybook/next.ts
@@ -52,7 +52,12 @@ export default class StoryBookNext extends Generator {
     // read sm file for local libraries.
     const localLibs = libraries.filter(lib => lib.startsWith('@/')).map(lib => lib.substring(2))
 
-    const stories = localLibs.map(p => `../${p}/**/*.stories.[tj]s`)
+    const stories = localLibs.reduce<ReadonlyArray<string>>((acc, p) => {
+      return acc.concat([
+        `../${p}/**/*.stories.[tj]s`,
+        `../.slicemachine/assets/${p}/**/*.stories.[tj]s`
+      ])
+    }, [])
 
     // TODO: add   "../.slicemachine/assets/slices/**/*.stories.js"
 

--- a/src/generators/slicemachine/storybook/nuxt.ts
+++ b/src/generators/slicemachine/storybook/nuxt.ts
@@ -2,7 +2,7 @@ import PrismicGenerator, {TemplateOptions, SliceMachineJson} from '../../prismic
 import modifyNuxtConfig from './modify-nuxt-config'
 const {SM_FILE} = require('sm-commons/consts')
 
-export default class StoryBookNext extends PrismicGenerator {
+export default class StoryBookNuxt extends PrismicGenerator {
   /**
    * initializing - Your initialization methods (checking current project state, getting configs, etc)
    * prompting - Where you prompt users for options (where you’d call this.prompt())

--- a/src/generators/slicemachine/storybook/nuxt.ts
+++ b/src/generators/slicemachine/storybook/nuxt.ts
@@ -53,7 +53,6 @@ export default class StoryBookNext extends PrismicGenerator {
     // TODO: add   "../.slicemachine/assets/slices/**/*.stories.js" to story book config.
 
     const config = this.readDestination('nuxt.config.js')
-
     const updatedConfig = modifyNuxtConfig(config, localLibs)
 
     this.writeDestination('nuxt.config.js', updatedConfig)

--- a/test/commands/new.test.ts
+++ b/test/commands/new.test.ts
@@ -220,7 +220,7 @@ describe('new', () => {
       const pathToNuxtConfig = path.join(fakeFolder, 'nuxt.config.js')
       expect(fs.existsSync(pathToNuxtConfig)).to.be.true
       const config = await fs.readFile(pathToNuxtConfig, {encoding: 'utf-8'})
-      expect(config).to.include('stories: ["~/slices/**/*.stories.[tj]s"]')
+      expect(config).to.include('stories: ["~/slices/**/*.stories.[tj]s", "~/.slicemachine/assets/slices/**/*.stories.[tj]s"]')
     })
   })
 

--- a/test/commands/slicemachine.test.ts
+++ b/test/commands/slicemachine.test.ts
@@ -143,7 +143,7 @@ describe('slicemachine', () => {
       const pathToNuxtConfig = path.join(fakeFolder, 'nuxt.config.js')
       expect(fs.existsSync(pathToNuxtConfig)).to.be.true
       const config = await fs.readFile(pathToNuxtConfig, {encoding: 'utf-8'})
-      expect(config).to.include('stories: ["~/slices/**/*.stories.[tj]s"]')
+      expect(config).to.include('stories: ["~/slices/**/*.stories.[tj]s", "~/.slicemachine/assets/slices/**/*.stories.[tj]s"]')
     })
   })
 

--- a/test/generators/storybook/modify-nuxt-config.test.ts
+++ b/test/generators/storybook/modify-nuxt-config.test.ts
@@ -25,14 +25,14 @@ describe('storybook#modify-nuxt-config', () => {
 
   it('should add storybook.stories = ["~/slices/**/*.stories.js"] to when no storybook property is found', () => {
     const input = 'export default {}'
-    expect(modifyNuxtConfig(input, ['slices'])).to.contain('stories: ["~/slices/**/*.stories.[tj]s"]')
+    expect(modifyNuxtConfig(input, ['slices'])).to.contain('stories: ["~/slices/**/*.stories.[tj]s", "~/.slicemachine/assets/slices/**/*.stories.[tj]s"]')
   })
 
   it('should add stories: ["~/slices/**/*.stories.js"] to when no storybook', () => {
     const input = `export default {
       storybook: {},
     }`
-    expect(modifyNuxtConfig(input, ['slices'])).to.contain('stories: ["~/slices/**/*.stories.[tj]s"]')
+    expect(modifyNuxtConfig(input, ['slices'])).to.contain('stories: ["~/slices/**/*.stories.[tj]s", "~/.slicemachine/assets/slices/**/*.stories.[tj]s"]')
   })
 
   it('should add "~/slices/**/*.stories.js" to stories field', () => {
@@ -41,17 +41,17 @@ describe('storybook#modify-nuxt-config', () => {
         stories: ["foo"]
       },
     }`
-    expect(modifyNuxtConfig(input, ['slices'])).to.contain('stories: ["foo", "~/slices/**/*.stories.[tj]s"]')
+    expect(modifyNuxtConfig(input, ['slices'])).to.contain('stories: ["foo", "~/slices/**/*.stories.[tj]s", "~/.slicemachine/assets/slices/**/*.stories.[tj]s"]')
   })
 
   it('should not add duplicate entries', () => {
     const input = `export default {
       storybook: {
-        stories: ["~/slices/**/*.stories.[tj]s"]
+        stories: ["~/slices/**/*.stories.[tj]s", "~/.slicemachine/assets/slices/**/*.stories.[tj]s"]
       },
     }`
 
-    expect(modifyNuxtConfig(input, ['slices'])).to.contain('stories: ["~/slices/**/*.stories.[tj]s"]')
+    expect(modifyNuxtConfig(input, ['slices'])).to.contain('stories: ["~/slices/**/*.stories.[tj]s", "~/.slicemachine/assets/slices/**/*.stories.[tj]s"]')
   })
 })
 


### PR DESCRIPTION
Now we generate both path for storybook in next and nuxt for each library registered.
One that targets the library folder itself (eg: `@/slices`) and one that is generated in `.slicemachine` (eg: `.slicemachine/assets/slices`)