### PR TITLE
fix: generator-generator TypeScript template bug and default Custom Type models

### DIFF
--- a/packages/generator-prismic-nextjs/generators/slicemachine/templates/customtypes/page/index.json
+++ b/packages/generator-prismic-nextjs/generators/slicemachine/templates/customtypes/page/index.json
@@ -1,6 +1,6 @@
 {
   "id": "page",
-  "name": "Page",
+  "label": "Page",
   "repeatable": true,
   "json": {
     "Page": {
@@ -57,10 +57,7 @@
                 "image_side": {
                   "type": "Select",
                   "config": {
-                    "options": [
-                      "left",
-                      "right"
-                    ],
+                    "options": ["left", "right"],
                     "default_value": "left",
                     "label": "Image side"
                   }
@@ -711,3 +708,4 @@
     }
   }
 }
+

--- a/packages/generator-prismic-nuxt/generators/slicemachine/templates/customtypes/page/index.json
+++ b/packages/generator-prismic-nuxt/generators/slicemachine/templates/customtypes/page/index.json
@@ -1,8 +1,8 @@
 {
   "id": "page",
-  "name": "Page",
+  "label": "Page",
   "repeatable": true,
-  "json":{
+  "json": {
     "Page": {
       "uid": {
         "type": "UID",
@@ -57,10 +57,7 @@
                 "image_side": {
                   "type": "Select",
                   "config": {
-                    "options": [
-                      "left",
-                      "right"
-                    ],
+                    "options": ["left", "right"],
                     "default_value": "left",
                     "label": "Image side"
                   }
@@ -711,3 +708,4 @@
     }
   }
 }
+

--- a/packages/prismic-generator-generator/app/templates/typescript/generators/slicemachine/index.ts
+++ b/packages/prismic-generator-generator/app/templates/typescript/generators/slicemachine/index.ts
@@ -58,7 +58,7 @@ export default class SliceMachine extends PrismicGenerator {
     return this.prismic.createRepository({
       domain: this.domain,
       customTypes,
-      framework: '<%= name >'
+      framework: '<%= name %>'
     }).then(res => {
       const url = new URL(this.prismic.base)
       url.host = `${res.data || this.domain}.${url.host}`


### PR DESCRIPTION
### 1. Fix default Slice Machine Custom Type models

The model should use the `label` property instead of the `name` property for its human-readable name.

Without this change, the Slice Machine UI shows no label (but does not show any error). It fails to upload to Prismic, but prints a success message.

---

### 2. Add missing closing EJS tag to Slice Machine w/ TypeScript template

Running the TypeScript generator with Slice Machine produced the following error:

```
$ ./bin/run create-generator
? name of the generator generator-prismic-test
? Language TypeScript
? package manager Npm
? Support SliceMachine Yes
    Error: Could not find matching close tag for "<%=".
```

This PR fixes the cause.
