### PR TITLE
Mm/themes ending with dot git

### DIFF
--- a/packages/prismic-cli/src/prismic/base-command.ts
+++ b/packages/prismic-cli/src/prismic/base-command.ts
@@ -130,6 +130,7 @@ export default abstract class PrismicCommand extends Command {
     if (this.isAbsoluteUrlToZip(source)) return source
     if (this.isGithubUrl(source) === false) return Promise.reject(new Error(`Could not guess where to find zip from ${source}`))
     const url = new URL(source)
+    url.pathname = url.pathname.replace(/.git$/, '')
 
     const maybeRepoAndBranch = /(\/.*\/.*\/)tree\/(.*)/.exec(url.pathname)
     if (maybeRepoAndBranch) {

--- a/packages/prismic-cli/test/prismic/base-command.test.ts
+++ b/packages/prismic-cli/test/prismic/base-command.test.ts
@@ -146,6 +146,19 @@ describe('prismic/base-command', () => {
     })
     .it('throws if not found')
 
+    test
+    .add('cmd', () => {
+      const opts = {} as IConfig
+      return new T([], opts)
+    })
+    .nock('https://github.com', api => {
+      api.head('/prismicio/fake/archive/main.zip').reply(200)
+    })
+    .it('should handle urls ending in .git', async ctx => {
+      const result = await ctx.cmd.maybeGitHubRepo('https://github.com/prismicio/fake.git')
+      expect(result).to.equal('https://github.com/prismicio/fake/archive/main.zip')
+    })
+
     // TODO: some other error for line 116
   })
 })


### PR DESCRIPTION
Fixes: https://github.com/prismicio/prismic-cli/issues/124
what happened was when a user used a theme url ending with `.git` the cli through that `.git` was part of the repository name and would search for `https://github.com/user/repo.git/archive/main.zip` when it should be `https://github.com/user/repo/archive/main.zip`