### PR TITLE
Mm/nuxt git username

### DIFF
--- a/packages/generator-prismic-nuxt/generators/app/index.ts
+++ b/packages/generator-prismic-nuxt/generators/app/index.ts
@@ -59,7 +59,16 @@ export default class Nuxt extends PrismicGenerator {
     const nuxtPrompts = NuxtPrompts.map(p => {
       if (p.name === 'name') return {...p, default: this.domain}
       // do the same for github user name
-      if (p.name === 'gitUsername') return {...p, default: this.user.github.username}
+      if (p.name === 'gitUsername') return {
+        ...p,
+        default: () => {
+          try {
+            return this.user.github.username()
+          } catch {
+            return this.user.git.name() || this.user.git.email()
+          }
+        },
+      }
       return p
     })
     const prompts = [...nuxtPrompts, {


### PR DESCRIPTION
User where reporting an issue with the nuxt generator that an error would be thrown when git was't configured with an email address.  (used during the prompts)

This has been fixed by catching the error and providing some fallbacks.

### To recreate 
using the currently published version of the cli
`npm install -g prismic-cli`

temporary move  ~/.gitconfig  and run `prismic new` and select `nuxt`