### PR TITLE
fix(generator-nuxt): update to how  getStoriesPaths is called

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ os:
 #  - osx
 
 node_js:
-  - node
+  - 16
   - 14
 
 jobs:
   include:
     - os: windows
+      node_js: 16
       env: YARN_GPG=no # so windows exits
 
     - os: windows

--- a/packages/generator-prismic-nextjs/generators/slicemachine/index.ts
+++ b/packages/generator-prismic-nextjs/generators/slicemachine/index.ts
@@ -85,7 +85,7 @@ export default class SliceMachine extends PrismicGenerator {
       },
       devDependencies: {
         '@babel/core': '^7.12.10',
-        'slice-machine-ui': 'beta',
+        'slice-machine-ui': '^0.1.2',
       },
     }
 

--- a/packages/generator-prismic-nuxt/generators/slicemachine/index.ts
+++ b/packages/generator-prismic-nuxt/generators/slicemachine/index.ts
@@ -76,7 +76,7 @@ export default class PrismicNuxt extends PrismicGenerator {
         sass: '^1.35.1',
         'css-loader': '^5.2.6',
         'sass-loader': '^10.1.1',
-        'slice-machine-ui': 'beta',
+        'slice-machine-ui': '^0.1.2',
       },
     }
 

--- a/packages/generator-prismic-nuxt/generators/storybook/index.ts
+++ b/packages/generator-prismic-nuxt/generators/storybook/index.ts
@@ -39,6 +39,7 @@ export default class StoryBookNuxt extends PrismicGenerator {
         'vue-loader': '15.9.6',
         '@nuxtjs/storybook': '3.3.1',
         'sass-loader': '^10.1.1',
+        'slice-machine-ui': '^0.1.2',
       },
     }
 

--- a/packages/generator-prismic-nuxt/generators/storybook/index.ts
+++ b/packages/generator-prismic-nuxt/generators/storybook/index.ts
@@ -34,9 +34,11 @@ export default class StoryBookNuxt extends PrismicGenerator {
         'build-storybook': 'nuxt storybook build',
       },
       devDependencies: {
+        sass: '^1.35.1',
         '@storybook/vue': '6.1.21',
         'vue-loader': '15.9.6',
         '@nuxtjs/storybook': '3.3.1',
+        'sass-loader': '^10.1.1',
       },
     }
 

--- a/packages/generator-prismic-nuxt/test/storybook/add-get-stories-paths.test.ts
+++ b/packages/generator-prismic-nuxt/test/storybook/add-get-stories-paths.test.ts
@@ -24,104 +24,125 @@ describe('add-get-stories-paths', () => {
       expect(result).to.equal(input)
     })
   })
+  const expectedCode = '...getStoriesPaths().map(path => path.replace("../", "~/"))'
 
   describe('upsertStories', () => {
-    it('should add a { storybook: { stories: [ ...getStoriesPaths() ] } } when no storybook property is found', () => {
+    it(`should add { stories: ${expectedCode} } when no storybook property is found`, () => {
       const input = 'export default {}'
       const result = addStories(input)
-      expect(result).to.equal('export default {\n  storybook: {\n    stories: [...getStoriesPaths()]\n  }\n};')
+      const wanted =
+`export default {
+  storybook: {
+    stories: [${expectedCode}]
+  }
+};`
+      expect(result).to.equal(wanted)
     })
 
-    it('should add a { stories :[ ...getStoriesPaths() ] } when storybook property is found', () => {
+    it(`should add a { stories : ${expectedCode} } when storybook property is found`, () => {
       const input = 'export default {\n  storybook: {}\n}'
       const result = addStories(input)
-      expect(result).to.equal('export default {\n  storybook: {\n    stories: [...getStoriesPaths()]\n  }\n};')
+      const wanted =
+`export default {
+  storybook: {
+    stories: [${expectedCode}]
+  }
+};`
+      expect(result).to.equal(wanted)
     })
 
-    it('should add ...getStoriesPaths() to the stories array', () => {
+    it(`should add ${expectedCode} to the stories array`, () => {
       const input = `export default {
         storybook: {
           stories: ["foo"]
         },
       }`
-      const expected = 'export default {\n  storybook: {\n    stories: ["foo", ...getStoriesPaths()]\n  }\n};'
+      const wanted =
+`export default {
+  storybook: {
+    stories: ["foo", ${expectedCode}]
+  }
+};`
 
       const result = addStories(input)
 
-      expect(result).to.equal(expected)
+      expect(result).to.equal(wanted)
     })
 
-    it('should not add ...getStoriesPaths() if it is already in the array', () => {
+    it(`should not add ${expectedCode} if it is already in the array`, () => {
+      const wanted =
+`export default {
+  storybook: {
+    stories: [${expectedCode}]
+  }
+};`
+      const result = addStories(wanted)
+      expect(wanted).equal(result)
+    })
+
+    it('should update the old ...getStoriesPath', () => {
       const input = 'export default {\n  storybook: {\n    stories: [...getStoriesPaths()]\n  }\n};'
+      const wanted =
+`export default {
+  storybook: {
+    stories: [${expectedCode}]
+  }
+};`
       const result = addStories(input)
-      expect(input).equal(result)
+      expect(result).equal(wanted)
     })
   })
 
   it('should add import and stories to export default {}', () => {
     const input = 'export default {};'
-    const expected = '' +
-    'import { getStoriesPaths } from \'slice-machine-ui/helpers/storybook\';\n' +
-    'export default {\n' +
-    '  storybook: {\n' +
-    '    stories: [...getStoriesPaths()]\n' +
-    '  }\n' +
-    '};'
+    const wanted =
+`import { getStoriesPaths } from 'slice-machine-ui/helpers/storybook';
+export default {
+  storybook: {
+    stories: [${expectedCode}]
+  }
+};`
     const result = addGetStoriesPaths(input)
 
-    expect(result).to.equal(expected)
+    expect(result).to.equal(wanted)
   })
 
   it('should add import and stories to export default { storybook: {}}', () => {
     const input = 'export default { storybook: {}};'
-    const expected = '' +
-    'import { getStoriesPaths } from \'slice-machine-ui/helpers/storybook\';\n' +
-    'export default {\n' +
-    '  storybook: {\n' +
-    '    stories: [...getStoriesPaths()]\n' +
-    '  }\n' +
-    '};'
+    const wanted =
+`import { getStoriesPaths } from 'slice-machine-ui/helpers/storybook';
+export default {
+  storybook: {
+    stories: [${expectedCode}]
+  }
+};`
     const result = addGetStoriesPaths(input)
 
-    expect(result).to.equal(expected)
-  })
-
-  it('should add import and stories to export default { storybook: {}}', () => {
-    const input = 'export default { storybook: {}};'
-    const expected = '' +
-    'import { getStoriesPaths } from \'slice-machine-ui/helpers/storybook\';\n' +
-    'export default {\n' +
-    '  storybook: {\n' +
-    '    stories: [...getStoriesPaths()]\n' +
-    '  }\n' +
-    '};'
-    const result = addGetStoriesPaths(input)
-
-    expect(result).to.equal(expected)
+    expect(result).to.equal(wanted)
   })
 
   it('should add import and stories to export default { storybook: { stories: ["foo"]}}', () => {
     const input = 'export default { storybook: { stories: ["foo"]}};'
-    const expected = '' +
-    'import { getStoriesPaths } from \'slice-machine-ui/helpers/storybook\';\n' +
-    'export default {\n' +
-    '  storybook: {\n' +
-    '    stories: ["foo", ...getStoriesPaths()]\n' +
-    '  }\n' +
-    '};'
+    const wanted =
+`import { getStoriesPaths } from 'slice-machine-ui/helpers/storybook';
+export default {
+  storybook: {
+    stories: ["foo", ${expectedCode}]
+  }
+};`
     const result = addGetStoriesPaths(input)
 
-    expect(result).to.equal(expected)
+    expect(result).to.equal(wanted)
   })
 
   it('should not add any duplicates', () => {
-    const input = '' +
-    'import { getStoriesPaths } from \'slice-machine-ui/helpers/storybook\';\n' +
-    'export default {\n' +
-    '  storybook: {\n' +
-    '    stories: ["foo", ...getStoriesPaths()]\n' +
-    '  }\n' +
-    '};'
+    const input =
+`import { getStoriesPaths } from 'slice-machine-ui/helpers/storybook';
+export default {
+  storybook: {
+    stories: ["foo", ${expectedCode}]
+  }
+};`
     const result = addGetStoriesPaths(input)
 
     expect(result).to.equal(input)

--- a/packages/prismic-cli/test/commands/new.test.ts
+++ b/packages/prismic-cli/test/commands/new.test.ts
@@ -242,7 +242,7 @@ describe('new', () => {
       const pathToNuxtConfig = path.join(fakeFolder, 'nuxt.config.js')
       expect(fs.existsSync(pathToNuxtConfig), 'should create nuxt.config.js').to.be.true
       const config = await fs.readFile(pathToNuxtConfig, {encoding: 'utf-8'})
-      expect(config, 'should add stories to nuxt config').to.include('stories: [...getStoriesPaths()]')
+      expect(config, 'should add stories to nuxt config').to.include('stories: [...getStoriesPaths().map(path => path.replace("../", "~/"))]')
       done()
     })
   })

--- a/packages/prismic-cli/test/commands/slicemachine.test.ts
+++ b/packages/prismic-cli/test/commands/slicemachine.test.ts
@@ -234,7 +234,7 @@ describe('slicemachine', () => {
       const pathToNuxtConfig = path.join(fakeFolder, 'nuxt.config.js')
       expect(fs.existsSync(pathToNuxtConfig), 'nuxt config not found').to.be.true
       const config = await fs.readFile(pathToNuxtConfig, {encoding: 'utf-8'})
-      expect(config).to.include('stories: [...getStoriesPaths()]')
+      expect(config).to.include('stories: [...getStoriesPaths().map(path => path.replace("../", "~/"))]')
       done()
     })
 

--- a/packages/prismic-cli/test/mocha.opts
+++ b/packages/prismic-cli/test/mocha.opts
@@ -2,4 +2,4 @@
 --watch-extensions ts
 --recursive
 --reporter spec
---timeout 10000
+--timeout 15000


### PR DESCRIPTION
Changes the call to `...getStoriesPaths` to `..getStoriesPaths().map(path => path.replace('../', '~/')`